### PR TITLE
World Clock is still 10x as fast as it should be.

### DIFF
--- a/Projects/CoX/Servers/MapServer/WorldSimulation.cpp
+++ b/Projects/CoX/Servers/MapServer/WorldSimulation.cpp
@@ -11,7 +11,7 @@ void World::update(const ACE_Time_Value &tick_timer)
     }
     else
         delta = tick_timer - prev_tick_time;
-    m_time_of_day+= 48*((float(delta.msec())/1000.0f)/(60.0*60)); // 1 sec of real time is 48s of ingame time
+    m_time_of_day+= 4.8*((float(delta.msec())/1000.0f)/(60.0*60)); // 1 sec of real time is 48s of ingame time
     if(m_time_of_day>=24.0f)
         m_time_of_day-=24.0f;
     sim_frame_time = delta.msec()/1000.0f;


### PR DESCRIPTION
For some reason this formula is incrementing 10x faster than it should. Slow it down.

Tested locally and the cycle hits precisely every 30min.

This doesn't completely resolve the issue, as the official servers had "midnight" in-game occurring on the hour and half hour precisely. This may have been a by-product of a consistent server-reset time daily, with the new world clock beginning precisely on the hour (2am or whatever time the server reset).

It's not clear what the repercussions, if any, there would be for not having midnight strike on the half-hour.